### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Deprecated in favor of [evm-lite-env](https://github.com/DLTcollab/evm-lite-env)
+
 # EVM Babble Environment
 Deploy environment for running evm-babble
 


### PR DESCRIPTION
Since evm-lite has no major problems, 
we will use evm-lite-env instead of evm-babble-env